### PR TITLE
ci: add commitlint to GitHub Action

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,14 @@
+name: commitlint
+on: 
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: ${ git rev-list --count origin }
+      - uses: wagoid/commitlint-github-action@v4


### PR DESCRIPTION
This commit will lint all previous commit comments.

Refs: #21