### PR TITLE
feat: remove settings related to local history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# Local History
-.history

--- a/sorachat/.gitignore
+++ b/sorachat/.gitignore
@@ -127,6 +127,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# Local History
-.history/

--- a/sorachat/.vscode/extensions.json
+++ b/sorachat/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
     "recommendations": [
         "ms-python.pylint",
-        "xyz.local-history",
         "DavidAnson.vscode-markdownlint",
         "streetsidesoftware.code-spell-checker"
     ]


### PR DESCRIPTION
This commit removes settings related to local history, as it became a standard feature in visual studio code version 1.66.
Refs: #28